### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/chattingagents.ipynb
+++ b/chattingagents.ipynb
@@ -27,7 +27,7 @@
     ">     * aprire il notebook `chattingagents.ipynb`\n",
     ">     * creare un ambiente virtuale locale Python (Select Kernel | Python Environments | Create Python Environment | Venv, e scegliere un interprete Python):\n",
     ">     * installare i moduli Python richiesti, eseguendo dal terminale:  \n",
-    ">         `pip install pyautogen`\n",
+    ">         `pip install ag2`\n",
     "> * eseguire dalla linea di comando:  \n",
     ">       `OLLAMA_MODELS=xxx OLLAMA_HOST=127.0.0.1:1234 ollama serve`  \n",
     "> dove `xxx` è la directory che contiene i modelli Ollama (in Linux potrebbe essere `/var/lib/ollama/.ollama/models`)"

--- a/computingagents.ipynb
+++ b/computingagents.ipynb
@@ -27,7 +27,7 @@
     ">     * aprire il notebook `computingagents.ipynb`\n",
     ">     * creare un ambiente virtuale locale Python (Select Kernel | Python Environments | Create Python Environment | Venv, e scegliere un interprete Python):\n",
     ">     * installare i moduli Python richiesti, eseguendo dal terminale:  \n",
-    ">         `pip install pyautogen`\n",
+    ">         `pip install ag2`\n",
     "> * eseguire dalla linea di comando:  \n",
     ">       `OLLAMA_MODELS=xxx OLLAMA_HOST=127.0.0.1:1234 ollama serve`  \n",
     "> dove `xxx` è la directory che contiene i modelli Ollama (in Linux potrebbe essere `/var/lib/ollama/.ollama/models`)"

--- a/websearchingagents.ipynb
+++ b/websearchingagents.ipynb
@@ -27,7 +27,7 @@
     ">     * aprire il notebook `websearchingagents.ipynb`\n",
     ">     * creare un ambiente virtuale locale Python (Select Kernel | Python Environments | Create Python Environment | Venv, e scegliere un interprete Python):\n",
     ">     * installare i moduli Python richiesti, eseguendo dal terminale:  \n",
-    ">         `pip install pyautogen duckduckgo_search`\n",
+    ">         `pip install ag2 duckduckgo_search`\n",
     "> * eseguire dalla linea di comando:  \n",
     ">       `OLLAMA_MODELS=xxx OLLAMA_HOST=127.0.0.1:1234 ollama serve`  \n",
     "> dove `xxx` è la directory che contiene i modelli Ollama (in Linux potrebbe essere `/var/lib/ollama/.ollama/models`)"


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
